### PR TITLE
[FIX] RCE through "timezone validation"

### DIFF
--- a/components/install/process.php
+++ b/components/install/process.php
@@ -42,6 +42,14 @@ function encryptPassword($p)
     return sha1(md5($p));
 }
 
+function validateTimezone($timezone)
+{
+
+    if (in_array($timezone, DateTimeZone::listIdentifiers()))
+        return $timezone;
+    return "UTC";
+}
+
 function cleanUsername($username)
 {
     return preg_replace('#[^A-Za-z0-9'.preg_quote('-_@. ').']#', '', $username);
@@ -83,7 +91,7 @@ if (!file_exists($users) && !file_exists($projects) && !file_exists($active)) {
     } else {
         $project_path = $project_name;
     }
-    $timezone = $_POST['timezone'];
+    $timezone = validateTimezone($_POST['timezone']);
 
     //////////////////////////////////////////////////////////////////
     // Create Projects files
@@ -160,7 +168,7 @@ define("WHITEPATHS", BASE_PATH . ",/home");
 $cookie_lifetime = "0";
 
 // TIMEZONE
-date_default_timezone_set("' . $_POST['timezone'] . '");
+date_default_timezone_set("' . validateTimezone($_POST['timezone']) . '");
 
 // External Authentification
 //define("AUTH_PATH", "/path/to/customauth.php");


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-packagist-codiad

### ⚙️ Description *

The `Codiad` project is vulnerable against `RCE` due to insecure `handling` of `user-supplied` inputs which are provided by the `attacker` on the `installation process`.

### 💻 Technical Description *

The `vulnerable parameter` was the `timezone` one which was formatted insecurely in a `PHP` file which was then executed and lead to `RCE`.
I modified the `timezone` process handling avoiding `invalid timezone` to be passed in the installation process, using the `DateTimeZone::listIdentifiers()` array of `valid and default timezones`.

If the `timezone` inserted by the user is inside the `valid list` of `DateTimeZone::listIdentifiers()`, then the request is accepted, while in contrary cases it's set a `UTC` default value which avoids the `RCE`.

### 🐛 Proof of Concept (PoC) *

1. Download the project
2. `php -S 0.0.0.0:8001`
3. Go on http://localtest.me:8001`
4. Fill the fields and intercept the `installation` request with Burp
5. Change the `timezone` parameter to to `'");system("touch%20HACKED");//#`
6. The `HACKED` file is created inside the `root directory`

### 🔥 Proof of Fix (PoF) *

Use the fixed version ... all works correctly but no `HACKED` file created :smile:

### 👍 User Acceptance Testing (UAT)

Only validating the `timezone` :smile: